### PR TITLE
Fix removeEventListener error

### DIFF
--- a/src/components/Keycode.js
+++ b/src/components/Keycode.js
@@ -10,7 +10,7 @@ const Keycode = () => {
   }
   useEffect(() => {
     document.addEventListener('keyup', getKeycode);
-    return () => document.removeEventListener('keyup');
+    return () => document.removeEventListener('keyup', getKeyCode);
   }, []);
   return (
     <>


### PR DESCRIPTION
Two parameters are needed for the  removeEventListener function call.